### PR TITLE
Improved Class Search Filters w/ Course Abbreviation + Course Value/CRN.

### DIFF
--- a/Uh-OH/backend/scrape/views.py
+++ b/Uh-OH/backend/scrape/views.py
@@ -12,7 +12,7 @@ def home(request):
     return render(request, template_name='base.html')
 
 class CourseAPIView(generics.ListCreateAPIView):
-    search_fields = ['courseName']
+    search_fields = ['courseName', 'courseAbbrev', 'courseValue']
     filter_backends = (filters.SearchFilter,)
     queryset = Course.objects.all()
     serializer_class = CourseSerializer


### PR DESCRIPTION
Hello Everyone.
This Pull Request simply is a quick and effective addition to our already existing Class Search Functionality.
Now, on the Frontend Main Uh-OH! Website, you should also be able to search based on Course Abbreviations + Course Value/CRN as opposed to simply just Course Name. 
Example: Try Searching CSCI-4440 and you will see that "Software, Design, + Documentation" pops up.
Hope this helps. 
Thank you.