### PR TITLE
Allow searching for '&' and prohibit searching for a blank field

### DIFF
--- a/Uh-OH/frontend/src/components/Search.js
+++ b/Uh-OH/frontend/src/components/Search.js
@@ -11,6 +11,20 @@ class Search extends React.Component {
 		search: "",
 	};
 	
+	// Formats the search query appropriately
+	formatSearchQuery(query) {
+		// if the query is empty, set it to null
+		// check if it is empty by replacing all whitespace with empty chars
+		var res = query.replace(/\s/g,'');
+		if(res == "")
+			query = null;
+
+		// replaces & with %26 to remove the default feature of searching
+		// with '&' to allow users to search for classes with '&' in their name
+		query = query.replace(/&/g, '%26');
+		return query;
+	}
+
 	async componentDidMount() {
 		try {
 			//get url to send to backend
@@ -18,6 +32,9 @@ class Search extends React.Component {
 			let searchURL = this.props.location.search;
 			let params = queryString.parse(searchURL);
 			var query = params["course_search_bar"];
+
+			// format the search query
+			query = this.formatSearchQuery(query);
 
 			//get response, convert to JSON
 			const res = await fetch(url + query);
@@ -35,7 +52,7 @@ class Search extends React.Component {
 
 			//storing what was searched
 			this.setState({
-				search: query
+				search: this.formatSearchQuery(query)
 			});
 		}
 		 catch(e){


### PR DESCRIPTION
Added formatSearchQuery() function in the Search component. Currently sets and whitespace searches to null and also formats searches to replace '&' with '%26' to allow classes such as "SOFTWARE DESIGN & DOCUME" to be searched for using the &.